### PR TITLE
Fixing truncated error output

### DIFF
--- a/markdownlint.js
+++ b/markdownlint.js
@@ -65,8 +65,7 @@ function lint(lintFiles, config) {
 
 function printResult(lintResult, hasErrors) {
   if (hasErrors) {
-    console.error(lintResult.toString());
-    process.exit(1);
+    process.stderr.write(lintResult.toString(), process.exit.bind(process, 1));
   } else {
     console.log(lintResult.toString());
   }


### PR DESCRIPTION
This is a [big annoying old bug](https://github.com/nodejs/node/pull/6773) that's been around forever apparently. On some systems (mac here, apparently affects windows as well), the following will not work as expected:

``` js
console.log(veryLongString);
process.exit();
```

Console.log is sync but output buffering (writing to stdout stream) is _async_, so:
- Tick + 0 first chunk is written
- Tick + 1 process.exit()
- Tick + 2 second chunk is written :x: **Never runs**

[The solution](https://github.com/nodejs/node/issues/6456#issuecomment-231279827) is to pass process.exit as a callback to process.stderr (where console.error goes).
## Before

```
$ markdownlint _includes/readmes/loopback-example-access-control.md
_includes/readmes/loopback-example-access-control.md: 1: MD018 No space after hash on atx style header
_includes/readmes/loopback-example-access-control.md: 22: MD018 No space after hash on atx style header
_includes/readmes/loopback-example-access-control.md: 24: MD018 No space after hash on atx style header
_includes/readmes/loopback-example-access-control.md: 31: MD018 No space after hash on atx style header
_includes/readmes/loopback-example-access-control.md: 39: MD018 No space after hash on atx style header
_includes/readmes/loopback-example-access-control.md: 41: MD018 No space after hash on atx style header
_includes/readmes/loopback-example-access-control.md: 43: MD018 No space after hash on atx style header
_includes/readmes/loopback-example-access-control.md: 54: MD018 No space after hash on atx style header
_includes/readmes/loopback-example-access-control.md: 56: MD018 No space after hash on atx style header
_includes/readmes/loopback-example-access-control.md: 97: MD018 No space after h%
$
```
## After

```
$ markdownlint _includes/readmes/loopback-example-access-control.md
_includes/readmes/loopback-example-access-control.md: 1: MD018 No space after hash on atx style header
_includes/readmes/loopback-example-access-control.md: 22: MD018 No space after hash on atx style header
_includes/readmes/loopback-example-access-control.md: 24: MD018 No space after hash on atx style header
_includes/readmes/loopback-example-access-control.md: 31: MD018 No space after hash on atx style header
_includes/readmes/loopback-example-access-control.md: 39: MD018 No space after hash on atx style header
_includes/readmes/loopback-example-access-control.md: 41: MD018 No space after hash on atx style header
_includes/readmes/loopback-example-access-control.md: 43: MD018 No space after hash on atx style header
_includes/readmes/loopback-example-access-control.md: 54: MD018 No space after hash on atx style header
_includes/readmes/loopback-example-access-control.md: 56: MD018 No space after hash on atx style header
_includes/readmes/loopback-example-access-control.md: 97: MD018 No space after hash on atx style header
_includes/readmes/loopback-example-access-control.md: 105: MD018 No space after hash on atx style header
_includes/readmes/loopback-example-access-control.md: 107: MD018 No space after hash on atx style header
_includes/readmes/loopback-example-access-control.md: 131: MD018 No space after hash on atx style header
_includes/readmes/loopback-example-access-control.md: 146: MD018 No space after hash on atx style header
_includes/readmes/loopback-example-access-control.md: 163: MD018 No space after hash on atx style header
_includes/readmes/loopback-example-access-control.md: 174: MD018 No space after hash on atx style header
_includes/readmes/loopback-example-access-control.md: 180: MD018 No space after hash on atx style header
_includes/readmes/loopback-example-access-control.md: 189: MD018 No space after hash on atx style header
_includes/readmes/loopback-example-access-control.md: 193: MD018 No space after hash on atx style header
_includes/readmes/loopback-example-access-control.md: 239: MD018 No space after hash on atx style header%
$
```
