### PR TITLE
Add support for pre-commit to markdownlint-cli

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,0 +1,7 @@
+-   id: markdownlint
+    name: markdownlint
+    description: "Checks the style of Markdown/Commonmark files."
+    entry: markdownlint
+    language: node
+    types: [markdown]
+    minimum_pre_commit_version: 0.15.0


### PR DESCRIPTION
This PR adds the ability to use `markdownlint-cli` as [pre-commit](http://pre-commit.com/) hook.