### PR TITLE
Updated markdownlint so that configurations could be extended

### DIFF
--- a/markdownlint.js
+++ b/markdownlint.js
@@ -14,17 +14,13 @@ var glob = require('glob');
 
 var pkg = require('./package');
 
-function readJSONFrom(file) {
-  return JSON.parse(fs.readFileSync(file));
-}
-
 function readConfiguration(args) {
   var config = rc('markdownlint', {});
   var projectConfigFile = '.markdownlint.json';
   var userConfigFile = args.config;
   try {
     fs.accessSync(projectConfigFile, fs.R_OK);
-    var projectConfig = readJSONFrom(projectConfigFile);
+    var projectConfig = markdownlint.readConfigSync(projectConfigFile);
     config = extend(config, projectConfig);
   } catch (err) {
   }
@@ -34,7 +30,7 @@ function readConfiguration(args) {
   // from .markdownlint.json.
   if (userConfigFile) {
     try {
-      var userConfig = readJSONFrom(userConfigFile);
+      var userConfig = markdownlint.readConfigSync(userConfigFile);
       config = extend(config, userConfig);
     } catch (err) {
       console.warn('Cannot read or parse config file', args.config);
@@ -44,7 +40,7 @@ function readConfiguration(args) {
 }
 
 function prepareFileList(files) {
-  files = files.map(function (file) {
+  files = files.map(file => {
     var isDir = fs.lstatSync(file).isDirectory();
     if (isDir) {
       var markdownFiles = path.join(file, '**', '*.md');
@@ -58,7 +54,7 @@ function prepareFileList(files) {
 function lint(lintFiles, config) {
   var lintOptions = {
     files: lintFiles,
-    config: config
+    config
   };
   return markdownlint.sync(lintOptions);
 }

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "glob": "~7.0.3",
     "lodash.flatten": "~4.3.0",
     "lodash.values": "~4.2.0",
-    "markdownlint": "~0.4.1",
+    "markdownlint": "~0.6.1",
     "rc": "~1.1.6"
   },
   "devDependencies": {

--- a/test/base-config.json
+++ b/test/base-config.json
@@ -1,0 +1,11 @@
+{
+  "default": true,
+
+  "MD003": { "style": "atx" },
+  "MD007": { "indent": 2 },
+  "MD013": { "line_length": 40 },
+  "MD033": false,
+  "MD034": false,
+  "no-hard-tabs": false,
+  "whitespace": false
+}

--- a/test/test-config.json
+++ b/test/test-config.json
@@ -1,10 +1,6 @@
 {
-  "default": true,
-  "MD003": { "style": "atx" },
+  "extends": "base-config.json",
+
   "MD007": { "indent": 4 },
-  "MD013": { "line_length": 200 },
-  "MD033": false,
-  "MD034": false,
-  "no-hard-tabs": false,
-  "whitespace": false
+  "MD013": { "line_length": 200 }
 }


### PR DESCRIPTION
I added a base-config to the tests to show that the extend functionality was working. 