### PR TITLE
fix #23 - use console error; process.exit alone; test

### DIFF
--- a/markdownlint.js
+++ b/markdownlint.js
@@ -61,21 +61,28 @@ function lint(lintFiles, config) {
 
 function printResult(lintResult, hasErrors) {
   if (hasErrors) {
-    process.stderr.write(lintResult.toString(), process.exit.bind(process, 1));
-  } else {
-    var result = lintResult.toString();
-    if (result) {
-      console.log(result);
-    }
+    console.error(lintResult.toString());
+    // Note: process.exit(1) will end abruptly, interrupting asynchronous IO
+    // streams (e.g., when the output is being piped). Just set the exit code
+    // and let the program terminate normally.
+    // @see {@link https://nodejs.org/dist/latest-v8.x/docs/api/process.html#process_process_exit_code}
+    // @see {@link https://github.com/igorshubovych/markdownlint-cli/pull/29#issuecomment-343535291}
+    process.exitCode = 1;
+    return;
+  }
+
+  var result = lintResult.toString();
+  if (result) {
+    console.log(result);
   }
 }
 
+function notEmptyObject(item) {
+  return Object.keys(item).length > 0;
+}
+
 function hasResultErrors(lintResult) {
-  function notEmptyObject(item) {
-    return Object.keys(item).length > 0;
-  }
-  return values(lintResult)
-    .some(notEmptyObject);
+  return values(lintResult).some(notEmptyObject);
 }
 
 program

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "node": ">=0.12.0"
   },
   "scripts": {
+    "invalid": "node ./markdownlint.js --config test/test-config.json -- test/incorrect.md",
     "test": "ava test/",
     "watch": "npm test -- --watch --tap | tap-growl",
     "start": "node ./markdownlint.js",

--- a/test/test.js
+++ b/test/test.js
@@ -43,3 +43,11 @@ test('linting of incorrect Markdown file fails', async t => {
     t.true(err.stderr.length > 0);
   }
 });
+
+test('linting of incorrect Markdown via npm run file fails with eol', async t => {
+  try {
+    await execa('npm', ['run', 'invalid']);
+  } catch (err) {
+    t.true(/\nnpm ERR! code ELIFECYCLE/.test(err.stderr));
+  }
+});


### PR DESCRIPTION
- Use console.error (still outputs to stderr)
- Simplify process.exit call
- Add "invalid" script for testing; test with regex newline where an npm run error would output on the same line