### PR TITLE
Update deep-extend and rc

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,13 +37,13 @@
   "homepage": "https://github.com/igorshubovych/markdownlint-cli#readme",
   "dependencies": {
     "commander": "~2.9.0",
-    "deep-extend": "~0.4.1",
+    "deep-extend": "~0.5.1",
     "get-stdin": "~5.0.1",
     "glob": "~7.0.3",
     "lodash.differencewith": "~4.5.0",
     "lodash.flatten": "~4.4.0",
     "markdownlint": "~0.8.1",
-    "rc": "~1.1.6"
+    "rc": "~1.2.7"
   },
   "devDependencies": {
     "ava": "^0.16.0",


### PR DESCRIPTION
In order to avoid security warning https://nodesecurity.io/advisories/612

You can see the security warnings by running `npm audit` (with `npm@6`)