### PR TITLE
Add support of custom rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,13 +19,13 @@ $ markdownlint --help
 
   Options:
 
-    -h, --help                          output usage information
-    -V, --version                       output the version number
-    -s, --stdin                         read from STDIN (no files)
-    -o, --output [outputFile]           write issues to file (no console)
-    -c, --config [configFile]           configuration file (JSON or YAML)
-    -r, --rules  [file|directory|glob]  custom rule files
-    -i, --ignore [file|directory|glob]  files to ignore/exclude
+    -h, --help                                  output usage information
+    -V, --version                               output the version number
+    -s, --stdin                                 read from STDIN (no files)
+    -o, --output [outputFile]                   write issues to file (no console)
+    -c, --config [configFile]                   configuration file (JSON or YAML)
+    -i, --ignore [file|directory|glob]          files to ignore/exclude
+    -r, --rules  [file|directory|glob|package]  custom rule files
 ```
 
 ## Configuration

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ $ markdownlint --help
     -s, --stdin                         read from STDIN (no files)
     -o, --output [outputFile]           write issues to file (no console)
     -c, --config [configFile]           configuration file (JSON or YAML)
-    -r, --rules [file]                  custom rule files
+    -r, --rules  [file|directory|glob]  custom rule files
     -i, --ignore [file|directory|glob]  files to ignore/exclude
 ```
 

--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ $ markdownlint --help
     -s, --stdin                         read from STDIN (no files)
     -o, --output [outputFile]           write issues to file (no console)
     -c, --config [configFile]           configuration file (JSON or YAML)
+    -r, --rules [file]                  custom rule files
     -i, --ignore [file|directory|glob]  files to ignore/exclude
 ```
 

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   },
   "scripts": {
     "invalid": "node ./markdownlint.js --config test/test-config.json -- test/incorrect.md",
-    "test": "ava test/",
+    "test": "ava",
     "watch": "npm test -- --watch --tap | tap-growl",
     "start": "node ./markdownlint.js",
     "precommit": "xo && npm test"
@@ -53,7 +53,8 @@
     "execa": "^0.6.3",
     "husky": "^0.11.3",
     "tap-growl": "^1.1.2",
-    "xo": "*"
+    "xo": "*",
+    "test-rule-package": "./test/custom-rules/test-rule-package"
   },
   "xo": {
     "space": true,
@@ -65,6 +66,10 @@
     }
   },
   "ava": {
+    "files": [
+        "test/**/*.js",
+        "!test/custom-rules/**/*.js"
+    ],
     "failFast": true,
     "babel": {
       "presets": [

--- a/test/custom-rules/files/test-rule-1.js
+++ b/test/custom-rules/files/test-rule-1.js
@@ -1,0 +1,10 @@
+module.exports = {
+  names: ['test-rule-1'],
+  description: 'Test rule broken',
+  tags: ['test'],
+  function: (params, onError) => {
+    onError({
+      lineNumber: 1
+    });
+  }
+};

--- a/test/custom-rules/files/test-rule-2.js
+++ b/test/custom-rules/files/test-rule-2.js
@@ -1,0 +1,10 @@
+module.exports = {
+  names: ['test-rule-2'],
+  description: 'Test rule 2 broken',
+  tags: ['test'],
+  function: (params, onError) => {
+    onError({
+      lineNumber: 1
+    });
+  }
+};

--- a/test/custom-rules/test-rule-package-other/index.js
+++ b/test/custom-rules/test-rule-package-other/index.js
@@ -1,0 +1,1 @@
+module.exports = require('./rule');

--- a/test/custom-rules/test-rule-package-other/package.json
+++ b/test/custom-rules/test-rule-package-other/package.json
@@ -1,0 +1,6 @@
+{
+    "name": "test-rule-package-other",
+    "main": "./index.js",
+    "version": "0.0.1",
+    "private": true
+}

--- a/test/custom-rules/test-rule-package-other/rule.js
+++ b/test/custom-rules/test-rule-package-other/rule.js
@@ -1,0 +1,10 @@
+module.exports = {
+  names: ['test-rule-package-other'],
+  description: 'Test rule package other broken',
+  tags: ['test'],
+  function: (params, onError) => {
+    onError({
+      lineNumber: 1
+    });
+  }
+};

--- a/test/custom-rules/test-rule-package/index.js
+++ b/test/custom-rules/test-rule-package/index.js
@@ -1,0 +1,10 @@
+module.exports = {
+  names: ['test-rule-package'],
+  description: 'Test rule package broken',
+  tags: ['test'],
+  function: (params, onError) => {
+    onError({
+      lineNumber: 1
+    });
+  }
+};

--- a/test/custom-rules/test-rule-package/package.json
+++ b/test/custom-rules/test-rule-package/package.json
@@ -1,0 +1,6 @@
+{
+    "name": "test-rule-package",
+    "main": "./index.js",
+    "version": "0.0.1",
+    "private": true
+}

--- a/test/test.js
+++ b/test/test.js
@@ -327,3 +327,105 @@ test('configuration file can be YAML', async t => {
   t.true(result.stdout === '');
   t.true(result.stderr === '');
 });
+
+test('Custom rule from single file loaded', async t => {
+  try {
+    var input = '# Input';
+    await execa('../markdownlint.js',
+      ['--rules', 'custom-rules/files/test-rule-1.js', '--stdin'], {input});
+    t.fail();
+  } catch (err) {
+    const expected = [
+      'stdin: 1: test-rule-1 Test rule broken',
+      ''
+    ].join('\n');
+    t.true(err.stdout === '');
+    t.true(err.stderr === expected);
+  }
+});
+
+test('Custom rules from directory loaded', async t => {
+  try {
+    var input = '# Input';
+    await execa('../markdownlint.js',
+      ['--rules', 'custom-rules/files', '--stdin'], {input});
+    t.fail();
+  } catch (err) {
+    const expected = [
+      'stdin: 1: test-rule-1 Test rule broken',
+      'stdin: 1: test-rule-2 Test rule 2 broken',
+      ''
+    ].join('\n');
+    t.true(err.stdout === '');
+    t.true(err.stderr === expected);
+  }
+});
+
+test('Custom rules from glob loaded', async t => {
+  try {
+    var input = '# Input';
+    await execa('../markdownlint.js',
+      ['--rules', 'custom-rules/files/**/*.js', '--stdin'], {input});
+    t.fail();
+  } catch (err) {
+    const expected = [
+      'stdin: 1: test-rule-1 Test rule broken',
+      'stdin: 1: test-rule-2 Test rule 2 broken',
+      ''
+    ].join('\n');
+    t.true(err.stdout === '');
+    t.true(err.stderr === expected);
+  }
+});
+
+test('Custom rule from node_modules package loaded', async t => {
+  try {
+    var input = '# Input';
+    await execa('../markdownlint.js',
+      ['--rules', 'test-rule-package', '--stdin'], {input});
+    t.fail();
+  } catch (err) {
+    const expected = [
+      'stdin: 1: test-rule-package Test rule package broken',
+      ''
+    ].join('\n');
+    t.true(err.stdout === '');
+    t.true(err.stderr === expected);
+  }
+});
+
+test('Custom rule from package loaded', async t => {
+  try {
+    var input = '# Input';
+    await execa('../markdownlint.js',
+      ['--rules', './custom-rules/test-rule-package', '--stdin'], {input});
+    t.fail();
+  } catch (err) {
+    const expected = [
+      'stdin: 1: test-rule-package Test rule package broken',
+      ''
+    ].join('\n');
+    t.true(err.stdout === '');
+    t.true(err.stderr === expected);
+  }
+});
+
+test('Custom rule from several packages loaded', async t => {
+  try {
+    var input = '# Input';
+    await execa('../markdownlint.js', [
+      '--rules', './custom-rules/test-rule-package',
+      '--rules', './custom-rules/test-rule-package-other',
+      '--stdin'
+    ], {input});
+    t.fail();
+  } catch (err) {
+    const expected = [
+      'stdin: 1: test-rule-package Test rule package broken',
+      'stdin: 1: test-rule-package-other Test rule package other broken',
+      ''
+    ].join('\n');
+    t.true(err.stdout === '');
+    t.true(err.stderr === expected);
+  }
+});


### PR DESCRIPTION
Added a way to pass custom rule scripts to linter.
* Use `-r` or `--rules` arg with path to js file following