### PR TITLE
Configuration is stored in JSON, YAML or INI files

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ $ markdownlint --help
 
 `markdownlint-cli` reuses [the rules][rules] from `markdownlint` package.
 
-Configuration is stored JSON or YAML files in the same [config format][config].
+Configuration is stored in JSON, YAML or INI files in the same [config format][config].
 
 The example of configuration file:
 

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ $ markdownlint --help
 
 `markdownlint-cli` reuses [the rules][rules] from `markdownlint` package.
 
-Configuration is stored JSON or INI files in the same [config format][config].
+Configuration is stored JSON or YAML files in the same [config format][config].
 
 The example of configuration file:
 


### PR DESCRIPTION
Two other places in the README say "JSON or YAML", so should this also say that instead of "JSON or INI"?