### PR TITLE
Fix error when an absolute path is given

### DIFF
--- a/markdownlint.js
+++ b/markdownlint.js
@@ -110,6 +110,7 @@ function prepareFileList(files, fileExtensions, previousResults) {
   return flatten(files).map(function (file) {
     return {
       original: file,
+      relative: path.relative(process.cwd(), file),
       absolute: path.resolve(file)
     };
   });
@@ -231,7 +232,7 @@ let ignoreFilter = () => true;
 if (existsSync(ignorePath)) {
   const ignoreText = fs.readFileSync(ignorePath, fsOptions);
   const ignoreInstance = ignore().add(ignoreText);
-  ignoreFilter = fileInfo => !ignoreInstance.ignores(fileInfo.original);
+  ignoreFilter = fileInfo => !ignoreInstance.ignores(fileInfo.relative);
 }
 
 const files = prepareFileList(program.args, ['md', 'markdown'])


### PR DESCRIPTION
When an absolute path is given (e.g. via `lint-staged`), `node-ignore` was throwing a RangeError `path should be a path.relative()'d string`.
see https://github.com/kaelzhang/node-ignore#1-pathname-should-be-a-pathrelatived-pathname

This is only a "quick win" to fix this issue.
As `prepareFileList` was already returning an `absolute` property based on the cwd, this commit only introduce a new `relative` property, which is also based on the cwd.
No new specific test was written for this use case.

Close #79 