### PR TITLE
Bump markdownlint to current version (0.20.1)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4738,9 +4738,9 @@
       }
     },
     "markdownlint": {
-      "version": "0.19.0",
-      "resolved": "https://registry.npmjs.org/markdownlint/-/markdownlint-0.19.0.tgz",
-      "integrity": "sha512-+MsWOnYVUH4klcKM7iRx5cno9FQMDAb6FC6mWlZkeXPwIaK6Z5Vd9VkXkykPidRqmLHU2wI+MNyfUMnUCBw3pQ==",
+      "version": "0.20.1",
+      "resolved": "https://registry.npmjs.org/markdownlint/-/markdownlint-0.20.1.tgz",
+      "integrity": "sha512-jq1qt0QkzY6AiN6O3tq+8SmUlvKfhx9GRKBn/IWEuN6RM5xBZG47rfW9Fn0eRvuozf5Xc59dRaLUZEO0XiyGOg==",
       "requires": {
         "markdown-it": "10.0.0"
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -4746,9 +4746,9 @@
       }
     },
     "markdownlint-rule-helpers": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/markdownlint-rule-helpers/-/markdownlint-rule-helpers-0.7.0.tgz",
-      "integrity": "sha512-xZByWJNBaCMHo7nYPv/5aO8Jt68YcMvyouFXhuXmJzbqCsQy8rfCj0kYcv22kdK5PwAgMdbHg0hyTdURbUZtJw=="
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/markdownlint-rule-helpers/-/markdownlint-rule-helpers-0.8.0.tgz",
+      "integrity": "sha512-myfbNm7Dk5YiWrShat3yjlp9GhoV4YY3pfKBRHuBSYKhVMm+b3L/ZvLdKzUdnwLJkTHj1zOvCPvBu5cBTc6vZQ=="
     },
     "matcher": {
       "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "lodash.differencewith": "~4.5.0",
     "lodash.flatten": "~4.4.0",
     "markdownlint": "~0.20.1",
-    "markdownlint-rule-helpers": "~0.7.0",
+    "markdownlint-rule-helpers": "~0.8.0",
     "minimatch": "~3.0.4",
     "rc": "~1.2.7"
   },

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "jsonc-parser": "~2.2.0",
     "lodash.differencewith": "~4.5.0",
     "lodash.flatten": "~4.4.0",
-    "markdownlint": "~0.19.0",
+    "markdownlint": "~0.20.1",
     "markdownlint-rule-helpers": "~0.7.0",
     "minimatch": "~3.0.4",
     "rc": "~1.2.7"


### PR DESCRIPTION
Is there anything else required to use Markdownlint v0.20.1?