### PR TITLE
bumping Dockerfile to node 12

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:8-alpine
+FROM node:12-alpine
 
 WORKDIR /usr/src/app
 


### PR DESCRIPTION
The old Node 8 baseimage was a bad fit, bumping to 12 (LTS version of Node)