### PR TITLE
README: add Homebrew installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,12 @@
 npm install -g markdownlint-cli
 ```
 
+On macOS you can install via [Homebrew](https://brew.sh/):
+
+```bash
+brew install markdownlint-cli
+```
+
 ## Usage
 
 ```bash


### PR DESCRIPTION
Adds installation instructions for Homebrew: https://formulae.brew.sh/formula/markdownlint-cli

Resolves #111 