### PR TITLE
fix: Update CI badge name

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,8 +119,8 @@ A JS configuration file may internally `require` one or more npm packages as a w
 
 MIT © Igor Shubovych
 
-[actions-badge]: https://github.com/igorshubovych/markdownlint-cli/workflows/Test/badge.svg?branch=master
-[actions-url]: https://github.com/igorshubovych/markdownlint-cli/actions?query=workflow%3ATest
+[actions-badge]: https://github.com/igorshubovych/markdownlint-cli/workflows/CI/badge.svg?branch=master
+[actions-url]: https://github.com/igorshubovych/markdownlint-cli/actions?query=workflow%3ACI
 
 [markdownlint]: https://github.com/DavidAnson/markdownlint
 [rules]: https://github.com/DavidAnson/markdownlint/blob/main/doc/Rules.md


### PR DESCRIPTION
Missed that the job name is part of these URLs when I renamed the job in the previous PR