### PR TITLE
feat: only fix specific rules

### DIFF
--- a/markdownlint.js
+++ b/markdownlint.js
@@ -273,7 +273,7 @@ function lintAndPrint(stdin, files) {
     };
   }
 
-  if (program.fix || program.fixRule) {
+  if (program.fix || program.fixRule.length > 0) {
     const fixOptions = {
       ...lintOptions,
       resultVersion: 3
@@ -307,7 +307,7 @@ function lintAndPrint(stdin, files) {
 
 if ((files.length > 0) && !program.stdin) {
   lintAndPrint(null, diff);
-} else if ((files.length === 0) && program.stdin && !program.fix && !program.fixRule) {
+} else if ((files.length === 0) && program.stdin && !program.fix && program.fixRule.length === 0) {
   const getStdin = require('get-stdin');
   getStdin().then(lintAndPrint);
 } else {


### PR DESCRIPTION
I have a use-case where I'd only like to automatically fix specific rules (just ones related to whitespace really) without necessarily fixing all rules.

This PR makes that possible with a new `--fix-rule` flag, which can be used multiple times to specify multiple rules.

I don't really love the flag name and all, but was trying to match the style of the other flags, like `--rules`. I'd personally probably prefer a comma-separated list of rules since it's less verbose, maybe `--fix-rules [rule,]`, or just make `--fix` take an optional list of rules, otherwise fix all.

So, feedback welcome on the flag.

Can update `README.md` and add a test into this PR once feedback solidifies the final form for the flag.