### PR TITLE
Add End of File Newline to program.output

### DIFF
--- a/markdownlint.js
+++ b/markdownlint.js
@@ -163,19 +163,17 @@ function printResult(lintResult) {
   }
 
   if (program.output) {
-      try {
-        if (lintResultString.length > 0) {
-          fs.writeFileSync(program.output, lintResultString + os.EOL); // We need to append a newline to make a valid POSIX file.
-        }
-        else {
-          fs.writeFileSync(program.output, lintResultString); // This is effectively writing a blank file.
-        }
-      } catch (error) {
-        console.warn('Cannot write to output file ' + program.output + ': ' + error.message);
-        process.exitCode = 2;
-      }
-  } else if (lintResultString) {
-    console.error(lintResultString);
+    lintResultString = lintResultString.length > 0 ?
+      lintResultString + os.EOL :
+      lintResultString
+    try {
+      fs.writeFileSync(program.output, lintResultString);
+    } catch (error) {
+      console.warn('Cannot write to output file ' + program.output + ': ' + error.message);
+      process.exitCode = 2;
+    }
+    } else if (lintResultString) {
+      console.error(lintResultString);
   }
 }
 

--- a/markdownlint.js
+++ b/markdownlint.js
@@ -14,6 +14,7 @@ const glob = require('glob');
 const minimatch = require('minimatch');
 const minimist = require('minimist');
 const pkg = require('./package');
+const os = require ('os');
 
 function jsoncParse(text) {
   return JSON.parse(require('jsonc-parser').stripComments(text));
@@ -162,22 +163,17 @@ function printResult(lintResult) {
   }
 
   if (program.output) {
-    if (lintResultString.length > 0) {
       try {
-        fs.writeFileSync(program.output, lintResultString + '\n'); // We need to append a newline to make a valid POSIX file.
+        if (lintResultString.length > 0) {
+          fs.writeFileSync(program.output, lintResultString + os.EOL); // We need to append a newline to make a valid POSIX file.
+        }
+        else {
+          fs.writeFileSync(program.output, lintResultString); // This is effectively writing a blank file.
+        }
       } catch (error) {
         console.warn('Cannot write to output file ' + program.output + ': ' + error.message);
         process.exitCode = 2;
       }
-    }
-    else {
-      try {
-        fs.writeFileSync(program.output, lintResultString); // This is effectively writing a blank file.
-      } catch (error) {
-        console.warn('Cannot write to output file ' + program.output + ': ' + error.message);
-        process.exitCode = 2;
-      }
-    }
   } else if (lintResultString) {
     console.error(lintResultString);
   }

--- a/markdownlint.js
+++ b/markdownlint.js
@@ -172,7 +172,7 @@ function printResult(lintResult) {
       console.warn('Cannot write to output file ' + program.output + ': ' + error.message);
       process.exitCode = 2;
     }
-    } else if (lintResultString) {
+  } else if (lintResultString) {
       console.error(lintResultString);
   }
 }

--- a/markdownlint.js
+++ b/markdownlint.js
@@ -163,7 +163,7 @@ function printResult(lintResult) {
 
   if (program.output) {
     try {
-      fs.writeFileSync(program.output, lintResultString);
+      fs.writeFileSync(program.output, lintResultString + '\n');
     } catch (error) {
       console.warn('Cannot write to output file ' + program.output + ': ' + error.message);
       process.exitCode = 2;

--- a/markdownlint.js
+++ b/markdownlint.js
@@ -162,11 +162,21 @@ function printResult(lintResult) {
   }
 
   if (program.output) {
-    try {
-      fs.writeFileSync(program.output, lintResultString + '\n');
-    } catch (error) {
-      console.warn('Cannot write to output file ' + program.output + ': ' + error.message);
-      process.exitCode = 2;
+    if (lintResultString.length > 0) {
+      try {
+        fs.writeFileSync(program.output, lintResultString + '\n'); // We need to append a newline to make a valid POSIX file.
+      } catch (error) {
+        console.warn('Cannot write to output file ' + program.output + ': ' + error.message);
+        process.exitCode = 2;
+      }
+    }
+    else {
+      try {
+        fs.writeFileSync(program.output, lintResultString); // This is effectively writing a blank file.
+      } catch (error) {
+        console.warn('Cannot write to output file ' + program.output + ': ' + error.message);
+        process.exitCode = 2;
+      }
     }
   } else if (lintResultString) {
     console.error(lintResultString);

--- a/test/test.js
+++ b/test/test.js
@@ -729,14 +729,14 @@ test('--ignore-path fails for missing file', async t => {
 
 test('Linter text file --output must end with EOF newline', async t => {
   const output = '../outputE.txt';
-  let endOfLine = new RegExp(os.EOL + '$');
+  const endOfLine = new RegExp(os.EOL + '$');
   try {
     await execa('../markdownlint.js',
       ['--config', 'test-config.json', '--output', output, 'incorrect.md'],
       {stripFinalNewline: false});
     t.fail();
   } catch (error) {
-    t.is(endOfLine.test(fs.readFileSync(output, 'utf8')), true);
+    t.true(endOfLine.test(fs.readFileSync(output, 'utf8')));
     fs.unlinkSync(output);
   }
 });

--- a/test/test.js
+++ b/test/test.js
@@ -4,6 +4,7 @@ const fs = require('fs');
 const path = require('path');
 const test = require('ava');
 const execa = require('execa');
+const os = require('os');
 
 const errorPattern = /(\.md|\.markdown|\.mdf|stdin):\d+(:\d+)? MD\d{3}/gm;
 
@@ -723,5 +724,19 @@ test('--ignore-path fails for missing file', async t => {
   } catch (error) {
     t.is(error.stdout, '');
     t.regex(error.stderr, /enoent.*no such file or directory/i);
+  }
+});
+
+test('Linter text file --output must end with EOF newline', async t => {
+  const output = '../outputE.txt';
+  let endOfLine = new RegExp(os.EOL + '$');
+  try {
+    await execa('../markdownlint.js',
+      ['--config', 'test-config.json', '--output', output, 'incorrect.md'],
+      {stripFinalNewline: false});
+    t.fail();
+  } catch (error) {
+    t.is(endOfLine.test(fs.readFileSync(output, 'utf8')), true);
+    fs.unlinkSync(output);
   }
 });


### PR DESCRIPTION
The output file specified with the `-o` or `--output` flags should contain an EOF newline to be a valid POSIX file.

This PR adds an EOF newline to the output.