### PR TITLE
feat: add dot option to treat dots as normal characters

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,14 +29,14 @@ markdownlint --help
 
     -h, --help                                  output usage information
     -V, --version                               output the version number
-    -f, --fix                                   fix basic errors (does not work with STDIN)
-    -s, --stdin                                 read from STDIN (does not work with files)
-    -o, --output [outputFile]                   write issues to file (no console)
     -c, --config [configFile]                   configuration file (JSON, JSONC, JS, or YAML)
+    -d, --dot                                   include files/folders with a dot (for example `.github`)
+    -f, --fix                                   fix basic errors (does not work with STDIN)
     -i, --ignore [file|directory|glob]          file(s) to ignore/exclude
+    -o, --output [outputFile]                   write issues to file (no console)
     -p, --ignore-path [file]                    path to file with ignore pattern(s)
     -r, --rules  [file|directory|glob|package]  custom rule files
-    -d, --dot                                   include files/folders with a dot (for example `.github`)
+    -s, --stdin                                 read from STDIN (does not work with files)
 ```
 
 ### Globbing

--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ markdownlint --help
     -i, --ignore [file|directory|glob]          file(s) to ignore/exclude
     -p, --ignore-path [file]                    path to file with ignore pattern(s)
     -r, --rules  [file|directory|glob|package]  custom rule files
+    -d, --dot                                   include files/folders with a dot (for example `.github`)
 ```
 
 ### Globbing

--- a/markdownlint.js
+++ b/markdownlint.js
@@ -79,7 +79,7 @@ function readConfiguration(args) {
 function prepareFileList(files, fileExtensions, previousResults) {
   const globOptions = {
     nodir: true,
-    dot: true
+    dot: options.dot != null ? true : false
   };
   let extensionGlobPart = '*.';
   if (fileExtensions.length === 1) {
@@ -194,7 +194,8 @@ program
   .option('-c, --config [configFile]', 'configuration file (JSON, JSONC, JS, or YAML)')
   .option('-i, --ignore [file|directory|glob]', 'file(s) to ignore/exclude', concatArray, [])
   .option('-p, --ignore-path [file]', 'path to file with ignore pattern(s)')
-  .option('-r, --rules  [file|directory|glob|package]', 'custom rule files', concatArray, []);
+  .option('-r, --rules  [file|directory|glob|package]', 'custom rule files', concatArray, [])
+  .option('-d, --dot', 'include files/folders with a dot (for example `.github`)');
 
 program.parse(process.argv);
 

--- a/markdownlint.js
+++ b/markdownlint.js
@@ -78,8 +78,8 @@ function readConfiguration(args) {
 
 function prepareFileList(files, fileExtensions, previousResults) {
   const globOptions = {
-    nodir: true,
-    dot: options.dot != null ? true : false
+    dot: !!options.dot,
+    nodir: true
   };
   let extensionGlobPart = '*.';
   if (fileExtensions.length === 1) {
@@ -188,14 +188,14 @@ program
   .version(pkg.version)
   .description(pkg.description)
   .usage('[options] <files|directories|globs>')
-  .option('-f, --fix', 'fix basic errors (does not work with STDIN)')
-  .option('-s, --stdin', 'read from STDIN (does not work with files)')
-  .option('-o, --output [outputFile]', 'write issues to file (no console)')
   .option('-c, --config [configFile]', 'configuration file (JSON, JSONC, JS, or YAML)')
+  .option('-d, --dot', 'include files/folders with a dot (for example `.github`)')
+  .option('-f, --fix', 'fix basic errors (does not work with STDIN)')
   .option('-i, --ignore [file|directory|glob]', 'file(s) to ignore/exclude', concatArray, [])
+  .option('-o, --output [outputFile]', 'write issues to file (no console)')
   .option('-p, --ignore-path [file]', 'path to file with ignore pattern(s)')
   .option('-r, --rules  [file|directory|glob|package]', 'custom rule files', concatArray, [])
-  .option('-d, --dot', 'include files/folders with a dot (for example `.github`)');
+  .option('-s, --stdin', 'read from STDIN (does not work with files)');
 
 program.parse(process.argv);
 

--- a/markdownlint.js
+++ b/markdownlint.js
@@ -78,7 +78,8 @@ function readConfiguration(args) {
 
 function prepareFileList(files, fileExtensions, previousResults) {
   const globOptions = {
-    nodir: true
+    nodir: true,
+    dot: true
   };
   let extensionGlobPart = '*.';
   if (fileExtensions.length === 1) {

--- a/test/.folder/.file-with-dot.md
+++ b/test/.folder/.file-with-dot.md
@@ -1,0 +1,8 @@
+## header 2
+# header
+
+```fence
+$ code
+```
+
+text

--- a/test/.folder/incorrect-dot.md
+++ b/test/.folder/incorrect-dot.md
@@ -1,0 +1,26 @@
+## header 2
+# header
+
+```fence
+$ code
+```
+
+text
+
+```fence
+$ code
+```
+
+text
+
+```fence
+$ code
+```
+
+text
+
+```fence
+$ code
+```
+
+text

--- a/test/test.js
+++ b/test/test.js
@@ -740,3 +740,23 @@ test('Linter text file --output must end with EOF newline', async t => {
     fs.unlinkSync(output);
   }
 });
+
+test('--dot option to include folders/files with a dot', async (t) => {
+  try {
+    await execa('../markdownlint.js',
+      ['--config', 'test-config.json', '--dot', '**/incorrect-dot.md', '**/correct.md'],
+      {stripFinalNewline: false});
+    t.fail();
+  } catch (error) {
+    t.is(error.stdout, '');
+    t.is(error.stderr.match(errorPattern).length, 8);
+  }
+});
+
+test('without --dot option exclude folders/files with a dot', async (t) => {
+  const result = await execa('../markdownlint.js',
+    ['--config', 'test-config.json', '**/incorrect-dot.md', '**/correct.md'],
+    {stripFinalNewline: false});
+  t.is(result.stdout, '');
+  t.is(result.stderr, '');
+});

--- a/test/test.js
+++ b/test/test.js
@@ -744,18 +744,18 @@ test('Linter text file --output must end with EOF newline', async t => {
 test('--dot option to include folders/files with a dot', async (t) => {
   try {
     await execa('../markdownlint.js',
-      ['--config', 'test-config.json', '--dot', '**/incorrect-dot.md', '**/correct.md'],
+      ['--config', 'test-config.json', '--dot', '**/incorrect-dot.md', '**/.file-with-dot.md', '**/correct.md'],
       {stripFinalNewline: false});
     t.fail();
   } catch (error) {
     t.is(error.stdout, '');
-    t.is(error.stderr.match(errorPattern).length, 8);
+    t.is(error.stderr.match(errorPattern).length, 13);
   }
 });
 
 test('without --dot option exclude folders/files with a dot', async (t) => {
   const result = await execa('../markdownlint.js',
-    ['--config', 'test-config.json', '**/incorrect-dot.md', '**/correct.md'],
+    ['--config', 'test-config.json', '**/incorrect-dot.md', '**/.file-with-dot.md', '**/correct.md'],
     {stripFinalNewline: false});
   t.is(result.stdout, '');
   t.is(result.stderr, '');


### PR DESCRIPTION
Hey! 👋
Thanks for this CLI tool to use `markdownlint`. :+1: 

I'm using the CLI tool like this : `markdownlint '**/*.md' --ignore node_modules` but currently folders like `.github` are ignored, so my `CONTRIBUTING.md`, `PULL_REQUEST_TEMPLATE.md` etc files are ignored.
The current workaround is to use the CLI like this : `markdownlint '**/*.md' '.*/**/*.md' --ignore node_modules`.

I don't think it is wanted, in my opinion, when we're setting this globbing `'**/*.md'`, it means we want to lint **EVERY** markdown files in the project, regardless of their location in the folder structure, including folders with a dot.

The fix seems simple, we need to set `dot: true` in the `glob` options.
See: <https://www.npmjs.com/package/glob#dots>

Just to test I edited myself the source files in the `node_modules` with the fix of this PR, and it is indeed fixing the issue.