### PR TITLE
chore: use built-in setup-node NPM cache

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,6 +29,7 @@ jobs:
         uses: actions/setup-node@v2.5.0
         with:
           node-version: ${{ matrix.node }}
+          cache: npm
 
       - name: Install packages
         run: npm ci


### PR DESCRIPTION
setup-node now supports caching based off the lockfile