### PR TITLE
Standardize and improve exit code handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,9 +112,10 @@ If a rule is passed to both `--enable` and `--disable`, it will be disabled.
 `markdownlint-cli` returns one of the following exit codes:
 
 - `0`: Program ran successfully
-- `1`: Linting errors / bad parameter
+- `1`: Linting errors
 - `2`: Unable to write `-o`/`--output` output file
 - `3`: Unable to load `-r`/`--rules` custom rule
+- `4`: Unexpected error (e.g. malformed config)
 
 ## Use with pre-commit
 

--- a/markdownlint.js
+++ b/markdownlint.js
@@ -339,11 +339,9 @@ function main() {
   }
 }
 
-if (require.main === module) {
-  try {
-    main();
-  } catch (error) {
-    console.error(error);
-    process.exit(exitCodes.unexpectedError);
-  }
+try {
+  main();
+} catch (error) {
+  console.error(error);
+  process.exit(exitCodes.unexpectedError);
 }

--- a/markdownlint.js
+++ b/markdownlint.js
@@ -24,7 +24,12 @@ function jsYamlSafeLoad(text) {
   return require('js-yaml').load(text);
 }
 
-const exitCodes = { lintFindings: 1, unexpectedError: 2 };
+const exitCodes = {
+  lintFindings: 1,
+  failedToWriteOutput: 2,
+  failedToLoadCustomRules: 3,
+  unexpectedError: 4
+};
 
 const projectConfigFiles = [
   '.markdownlint.json',
@@ -241,7 +246,7 @@ function loadCustomRules(rules) {
       return fileList;
     } catch (error) {
       console.error('Cannot load custom rule ' + rule + ': ' + error.message);
-      return process.exit(3);
+      return process.exit(exitCodes.failedToLoadCustomRules);
     }
   });
 }
@@ -339,5 +344,6 @@ if (require.main === module) {
     main();
   } catch (error) {
     process.exitCode = exitCodes.unexpectedError;
+    throw error;
   }
 }

--- a/markdownlint.js
+++ b/markdownlint.js
@@ -328,7 +328,7 @@ function lintAndPrint(stdin, files) {
   printResult(lintResult);
 }
 
-function main() {
+try {
   if ((files.length > 0) && !options.stdin) {
     lintAndPrint(null, diff);
   } else if ((files.length === 0) && options.stdin && !options.fix) {
@@ -337,10 +337,6 @@ function main() {
   } else {
     program.help();
   }
-}
-
-try {
-  main();
 } catch (error) {
   console.error(error);
   process.exit(exitCodes.unexpectedError);

--- a/markdownlint.js
+++ b/markdownlint.js
@@ -26,7 +26,7 @@ function jsYamlSafeLoad(text) {
 
 const exitCodes = {
   lintFindings: 1,
-  failedToWriteOutput: 2,
+  failedToWriteOutputFile: 2,
   failedToLoadCustomRules: 3,
   unexpectedError: 4
 };
@@ -178,7 +178,7 @@ function printResult(lintResult) {
       fs.writeFileSync(options.output, lintResultString);
     } catch (error) {
       console.warn('Cannot write to output file ' + options.output + ': ' + error.message);
-      process.exitCode = exitCodes.unexpectedError;
+      process.exitCode = exitCodes.failedToWriteOutputFile;
     }
   } else if (lintResultString && !options.quiet) {
     console.error(lintResultString);
@@ -343,7 +343,7 @@ if (require.main === module) {
   try {
     main();
   } catch (error) {
-    process.exitCode = exitCodes.unexpectedError;
-    throw error;
+    console.error(error);
+    process.exit(exitCodes.unexpectedError);
   }
 }

--- a/test/test.js
+++ b/test/test.js
@@ -126,6 +126,20 @@ test('linting of incorrect Markdown file fails with absolute path', async t => {
   }
 });
 
+test('linting of unreadable Markdown file fails', async t => {
+  const unreadable_path = '/tmp/unreadable.md';
+  fs.writeFileSync(unreadable_path, '', {mode: 0o222});
+  try {
+    await execa('../markdownlint.js',
+      ['--config', 'test-config.json', unreadable_path],
+      {stripFinalNewline: false});
+    t.fail();
+  } catch (error) {
+    t.is(error.exitCode, 2);
+  }
+  fs.rmSync(unreadable_path, {force: true});
+});
+
 test('linting of incorrect Markdown via npm run file fails with eol', async t => {
   try {
     await execa('npm', ['run', 'invalid'], {stripFinalNewline: false});
@@ -472,7 +486,7 @@ test('error on configuration file not found', async t => {
   } catch (error) {
     t.is(error.stdout, '');
     t.regex(error.stderr, /Cannot read or parse config file 'non-existent-file-path.yaml': ENOENT: no such file or directory, open 'non-existent-file-path.yaml'/);
-    t.is(error.exitCode, 1);
+    t.is(error.exitCode, 2);
   }
 });
 
@@ -484,7 +498,7 @@ test('error on malformed YAML configuration file', async t => {
   } catch (error) {
     t.is(error.stdout, '');
     t.regex(error.stderr, /Cannot read or parse config file 'malformed-config.yaml': Unable to parse 'malformed-config.yaml'; Unexpected token/);
-    t.is(error.exitCode, 1);
+    t.is(error.exitCode, 2);
   }
 });
 

--- a/test/test.js
+++ b/test/test.js
@@ -127,19 +127,21 @@ test('linting of incorrect Markdown file fails with absolute path', async t => {
 });
 
 test('linting of unreadable Markdown file fails', async t => {
-  const unreadablePath = '/tmp/unreadable.md';
-  fs.writeFileSync(unreadablePath, '', {mode: 0o222});
-
+  const unreadablePath = '../unreadable.test.md';
   try {
-    await execa('../markdownlint.js',
-      ['--config', 'test-config.json', unreadablePath],
-      {stripFinalNewline: false});
-    t.fail();
-  } catch (error) {
-    t.is(error.exitCode, 4);
-  }
+    fs.writeFileSync(unreadablePath, '', {mode: 0o222});
 
-  fs.rmSync(unreadablePath, {force: true});
+    try {
+      await execa('../markdownlint.js',
+        ['--config', 'test-config.json', unreadablePath],
+        {stripFinalNewline: false});
+      t.fail();
+    } catch (error) {
+      t.is(error.exitCode, 4);
+    }
+  } finally {
+    fs.rmSync(unreadablePath, {force: true});
+  }
 });
 
 test('linting of incorrect Markdown via npm run file fails with eol', async t => {

--- a/test/test.js
+++ b/test/test.js
@@ -136,7 +136,7 @@ test('linting of unreadable Markdown file fails', async t => {
       {stripFinalNewline: false});
     t.fail();
   } catch (error) {
-    t.is(error.exitCode, 2);
+    t.is(error.exitCode, 4);
   }
 
   fs.rmSync(unreadablePath, {force: true});
@@ -488,7 +488,7 @@ test('error on configuration file not found', async t => {
   } catch (error) {
     t.is(error.stdout, '');
     t.regex(error.stderr, /Cannot read or parse config file 'non-existent-file-path.yaml': ENOENT: no such file or directory, open 'non-existent-file-path.yaml'/);
-    t.is(error.exitCode, 2);
+    t.is(error.exitCode, 4);
   }
 });
 
@@ -500,7 +500,7 @@ test('error on malformed YAML configuration file', async t => {
   } catch (error) {
     t.is(error.stdout, '');
     t.regex(error.stderr, /Cannot read or parse config file 'malformed-config.yaml': Unable to parse 'malformed-config.yaml'; Unexpected token/);
-    t.is(error.exitCode, 2);
+    t.is(error.exitCode, 4);
   }
 });
 

--- a/test/test.js
+++ b/test/test.js
@@ -127,17 +127,19 @@ test('linting of incorrect Markdown file fails with absolute path', async t => {
 });
 
 test('linting of unreadable Markdown file fails', async t => {
-  const unreadable_path = '/tmp/unreadable.md';
-  fs.writeFileSync(unreadable_path, '', {mode: 0o222});
+  const unreadablePath = '/tmp/unreadable.md';
+  fs.writeFileSync(unreadablePath, '', {mode: 0o222});
+
   try {
     await execa('../markdownlint.js',
-      ['--config', 'test-config.json', unreadable_path],
+      ['--config', 'test-config.json', unreadablePath],
       {stripFinalNewline: false});
     t.fail();
   } catch (error) {
     t.is(error.exitCode, 2);
   }
-  fs.rmSync(unreadable_path, {force: true});
+
+  fs.rmSync(unreadablePath, {force: true});
 });
 
 test('linting of incorrect Markdown via npm run file fails with eol', async t => {

--- a/test/test.js
+++ b/test/test.js
@@ -128,7 +128,7 @@ test('linting of incorrect Markdown file fails with absolute path', async t => {
 
 test('linting of unreadable Markdown file fails', async t => {
   const unreadablePath = '../unreadable.test.md';
-  fs.writeFileSync(unreadablePath, '', {mode: 0o222});
+  fs.symlinkSync('nonexistent.dest.md', unreadablePath, 'file');
 
   try {
     await execa('../markdownlint.js',
@@ -138,7 +138,7 @@ test('linting of unreadable Markdown file fails', async t => {
   } catch (error) {
     t.is(error.exitCode, 4);
   } finally {
-    fs.rmSync(unreadablePath, {force: true});
+    fs.unlinkSync(unreadablePath, {force: true});
   }
 });
 

--- a/test/test.js
+++ b/test/test.js
@@ -128,17 +128,15 @@ test('linting of incorrect Markdown file fails with absolute path', async t => {
 
 test('linting of unreadable Markdown file fails', async t => {
   const unreadablePath = '../unreadable.test.md';
-  try {
-    fs.writeFileSync(unreadablePath, '', {mode: 0o222});
+  fs.writeFileSync(unreadablePath, '', {mode: 0o222});
 
-    try {
-      await execa('../markdownlint.js',
-        ['--config', 'test-config.json', unreadablePath],
-        {stripFinalNewline: false});
-      t.fail();
-    } catch (error) {
-      t.is(error.exitCode, 4);
-    }
+  try {
+    await execa('../markdownlint.js',
+      ['--config', 'test-config.json', unreadablePath],
+      {stripFinalNewline: false});
+    t.fail();
+  } catch (error) {
+    t.is(error.exitCode, 4);
   } finally {
     fs.rmSync(unreadablePath, {force: true});
   }


### PR DESCRIPTION
This PR does two things:

  1.  standardize on:

      * `exit(1)` when markdownlint runs successfully but finds issues in the input and

      * `exit(2)` when markdownlint fails to run successfully, perhaps because a configuration file is malformed or perhaps because some kind of filesystem error has occurred

  2.  handle errors more robustly: a runtime error inside `lintAndPrint()` today results in `exit(1)`, e.g. for a file that we don't have read permissions on (note: this is not comprehensive, we do still do some code execution before `lintAndPrint()`, but this is still a solid improvement)

The background for this PR is that I'm working on [a universal linter](https;//trunk.io/products/check) which makes it easy for users to run linters for different subsets of their repos, and `markdownlint-cli` uses `exit(1)` as a catch-all for not just lint findings but also unexpected failures.

Specifically we've seen `markdownlint` return with `exit(1)` when this happens:

```
internal/fs/utils.js:314
    throw err;
    ^

Error: ENOENT: no such file or directory, open '[sanitized]'
    at Object.openSync (fs.js:498:3)
    at Object.readFileSync (fs.js:394:35)
    at lintFile ([sanitized]/.cache/trunk/linters/markdownlint/0.29.0-ee485b2571c3867cdf56d258aa9aed05/node_modules/markdownlint/lib/markdownlint.js:714:33)
    at lintInput ([sanitized]/.cache/trunk/linters/markdownlint/0.29.0-ee485b2571c3867cdf56d258aa9aed05/node_modules/markdownlint/lib/markdownlint.js:790:7)
    at Function.markdownlintSync [as sync] ([sanitized]/.cache/trunk/linters/markdownlint/0.29.0-ee485b2571c3867cdf56d258aa9aed05/node_modules/markdownlint/lib/markdownlint.js:888:3)
    at lintAndPrint ([sanitized]/.cache/trunk/linters/markdownlint/0.29.0-ee485b2571c3867cdf56d258aa9aed05/node_modules/markdownlint-cli/markdownlint.js:324:35)
    at Object.<anonymous> ([sanitized]/.cache/trunk/linters/markdownlint/0.29.0-ee485b2571c3867cdf56d258aa9aed05/node_modules/markdownlint-cli/markdownlint.js:329:3)
    at Module._compile (internal/modules/cjs/loader.js:1072:14)
    at Object.Module._extensions..js (internal/modules/cjs/loader.js:1101:10)
    at Module.load (internal/modules/cjs/loader.js:937:32) {
  errno: -2,
  syscall: 'open',
  code: 'ENOENT',
  path: '[sanitized]'
}
```

and this can be easily reproduced via:

```
touch foo.md
chmod a-r foo.md
markdownlint-cli foo.md
```