### PR TITLE
chore: disable Ava Workers

### DIFF
--- a/package.json
+++ b/package.json
@@ -73,6 +73,7 @@
       "!test/custom-rules/**/*.js",
       "!test/md043-config.js"
     ],
-    "failFast": true
+    "failFast": true,
+    "workerThreads": false
   }
 }


### PR DESCRIPTION
See if it resolves the failure for process.chdir with Ava v4