### PR TITLE
.pre-commit-hooks.yaml: add markdownlint-docker

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -18,3 +18,9 @@
     entry: ghcr.io/igorshubovych/markdownlint-cli
     language: docker_image
     types: [markdown]
+-   id: markdownlint-fix-docker
+    name: markdownlint-fix-docker
+    description: "Fixes the style of Markdown/Commonmark files, uses projects official docker image.."
+    entry: ghcr.io/igorshubovych/markdownlint-cli --fix
+    language: docker_image
+    types: [markdown]

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -18,9 +18,11 @@
     entry: ghcr.io/igorshubovych/markdownlint-cli
     language: docker_image
     types: [markdown]
+    minimum_pre_commit_version: 0.15.0
 -   id: markdownlint-fix-docker
     name: markdownlint-fix-docker
     description: "Fixes the style of Markdown/Commonmark files."
     entry: ghcr.io/igorshubovych/markdownlint-cli --fix
     language: docker_image
     types: [markdown]
+    minimum_pre_commit_version: 0.15.0

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -14,13 +14,13 @@
     minimum_pre_commit_version: 0.15.0
 -   id: markdownlint-docker
     name: markdownlint-docker
-    description: "Checks the style of Markdown/Commonmark files, uses projects official docker image."
+    description: "Checks the style of Markdown/Commonmark files."
     entry: ghcr.io/igorshubovych/markdownlint-cli
     language: docker_image
     types: [markdown]
 -   id: markdownlint-fix-docker
     name: markdownlint-fix-docker
-    description: "Fixes the style of Markdown/Commonmark files, uses projects official docker image.."
+    description: "Fixes the style of Markdown/Commonmark files."
     entry: ghcr.io/igorshubovych/markdownlint-cli --fix
     language: docker_image
     types: [markdown]

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -12,3 +12,9 @@
     language: node
     types: [markdown]
     minimum_pre_commit_version: 0.15.0
+-   id: markdownlint-docker
+    name: markdownlint-docker
+    description: "Checks the style of Markdown/Commonmark files, uses projects official docker image."
+    entry: ghcr.io/igorshubovych/markdownlint-cli
+    language: docker_image
+    types: [markdown]


### PR DESCRIPTION
It can be useful to run the tool via container for pre-hook if one does
not feel like installing node on the host system.

Signed-off-by: Maciej Pijanowski <maciej.pijanowski@3mdeb.com>