### PR TITLE
Enable npm `engine-strict` to test for unsupported dependencies

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+engine-strict=true


### PR DESCRIPTION
Detect issues like:
*  #508

It turns a warning into a fatal error so that the issue would be caught on CI when testing against the supported Node versions:

```
❯ npm ci
npm ERR! code EBADENGINE
npm ERR! engine Unsupported engine
npm ERR! engine Not compatible with your version of node/npm: glob@11.0.0
npm ERR! notsup Not compatible with your version of node/npm: glob@11.0.0
npm ERR! notsup Required: {"node":"20 || >=22"}
npm ERR! notsup Actual:   {"npm":"10.5.0","node":"v18.20.2"}
```

Personally, I wish this was the default behavior.