### PR TITLE
Say what happened when the given files match nothing

### DIFF
--- a/markdownlint.js
+++ b/markdownlint.js
@@ -339,6 +339,11 @@ try {
     lintAndPrint(null, diff);
   } else if (inputs.length === 0 && options.stdin && !options.fix) {
     import('node:stream/consumers').then(module => module.text(process.stdin)).then(lintAndPrint);
+  } else if (program.args.length > 0 && !options.stdin) {
+    // Files, directories, or globs were given, but none of them resolved to a
+    // Markdown file. That is not a usage error, so say what happened instead
+    // of printing the help text and leaving the user to guess.
+    console.error('No matching files found.');
   } else {
     program.help();
   }

--- a/markdownlint.js
+++ b/markdownlint.js
@@ -340,10 +340,8 @@ try {
   } else if (inputs.length === 0 && options.stdin && !options.fix) {
     import('node:stream/consumers').then(module => module.text(process.stdin)).then(lintAndPrint);
   } else if (program.args.length > 0 && !options.stdin) {
-    // Files, directories, or globs were given, but none of them resolved to a
-    // Markdown file. That is not a usage error, so say what happened instead
-    // of printing the help text and leaving the user to guess.
-    console.error('No matching files found.');
+    // Files, directories, or globs were given, but none of them resolved to a Markdown file.
+    console.warn('No matching files found');
   } else {
     program.help();
   }

--- a/test/test.js
+++ b/test/test.js
@@ -44,17 +44,24 @@ test('no files shows help', async t => {
   t.is(result.exitCode, 0);
 });
 
-test('globs that match nothing report that, not usage', async t => {
-  const result = await spawn('../markdownlint.js', ['no-such-directory/**/*.md']);
+test('a missing file reports that', async t => {
+  const result = await spawn('../markdownlint.js', ['no-such-file.md']);
   t.is(result.stdout, '');
-  t.is(result.stderr, 'No matching files found.');
+  t.is(result.stderr, 'No matching files found');
   t.is(result.exitCode, 0);
 });
 
-test('a missing file reports that, not usage', async t => {
-  const result = await spawn('../markdownlint.js', ['no-such-file.md']);
+test('a missing directory reports that', async t => {
+  const result = await spawn('../markdownlint.js', ['no-such-directory']);
   t.is(result.stdout, '');
-  t.is(result.stderr, 'No matching files found.');
+  t.is(result.stderr, 'No matching files found');
+  t.is(result.exitCode, 0);
+});
+
+test('globs that match nothing report that', async t => {
+  const result = await spawn('../markdownlint.js', ['no-such-directory/**/*.md']);
+  t.is(result.stdout, '');
+  t.is(result.stderr, 'No matching files found');
   t.is(result.exitCode, 0);
 });
 

--- a/test/test.js
+++ b/test/test.js
@@ -44,6 +44,20 @@ test('no files shows help', async t => {
   t.is(result.exitCode, 0);
 });
 
+test('globs that match nothing report that, not usage', async t => {
+  const result = await spawn('../markdownlint.js', ['no-such-directory/**/*.md']);
+  t.is(result.stdout, '');
+  t.is(result.stderr, 'No matching files found.');
+  t.is(result.exitCode, 0);
+});
+
+test('a missing file reports that, not usage', async t => {
+  const result = await spawn('../markdownlint.js', ['no-such-file.md']);
+  t.is(result.stdout, '');
+  t.is(result.stderr, 'No matching files found.');
+  t.is(result.exitCode, 0);
+});
+
 test('files and --stdin shows help', async t => {
   const result = await spawn('../markdownlint.js', ['--stdin', 'correct.md']);
   t.true(result.stdout.includes('--help'));


### PR DESCRIPTION
Fixes #104.

A glob or path that resolves to no Markdown file leaves `inputs` empty — the same state as being given no arguments at all — so the dispatch at the bottom of `markdownlint.js` falls through to `program.help()`:

```console
$ cd a-project-with-no-markdown
$ markdownlint --fix '**/*.md'
Usage: markdownlint [options] [files|directories|globs...]
...
```

That output is indistinguishable from running `markdownlint` with no arguments, so it reads as "you typed the command wrong" when the command was fine and the directory simply held no Markdown. That's what @paulmelnikow ran into, and #304 upstream.

The new branch is taken only when operands were actually given and `--stdin` wasn't, so the three cases that legitimately show usage — no arguments, files with `--stdin`, `--fix` with `--stdin` — keep doing so, and their tests still pass unchanged.

The message goes to stderr, which leaves `--output`, `--json` and `--quiet` consumers of stdout untouched. **The exit status is unchanged (0)**: a build that lints a tree which happens to contain no Markdown passes today and still passes, so this isn't a breaking change for anyone's CI.

Two tests cover it — a glob that matches nothing and a path to a file that doesn't exist. Both fail on current `master` (they get the help text) and pass with the change. The full suite is green at 91 tests, and `xo` is clean.

AI-assisted (LLM used for drafting); the runs above are mine.
